### PR TITLE
chore(flake/precommit): `6d12f2a0` -> `cb27f0e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1775320680,
-        "narHash": "sha256-nw3uNIw3DrBVyrTUkQlVGFEd7Fqn+YyTad8dUp/DTTE=",
+        "lastModified": 1777597424,
+        "narHash": "sha256-2szcq71hbF+FK4XrJa+sERYVo5rQVjPmxWjTMedLIXM=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "6d12f2a02b764b7f202613cb1447dd6aba71dd4b",
+        "rev": "cb27f0e8312a14e144978fac6963d55897aa6dea",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1775272153,
-        "narHash": "sha256-FwYb64ysv8J2TxaqsYYcDyHAHBUEaQlriPMWPMi1K7M=",
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "740fb0203b2852917b909a72b948d34d0b171ec0",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`cb27f0e8`](https://github.com/fredsystems/pre-commit-checks/commit/cb27f0e8312a14e144978fac6963d55897aa6dea) | `` chore(flake/nixpkgs): 4bd9165a -> 1c3fe55a ``                                 |
| [`581fdd93`](https://github.com/fredsystems/pre-commit-checks/commit/581fdd9390cc1e0a93a12036586c1511bad9ddb2) | `` chore(flake/rust-overlay): 62e3b8ae -> 09b556f1 ``                            |
| [`95a52f65`](https://github.com/fredsystems/pre-commit-checks/commit/95a52f6561b19e4d8c206121d546ab333187eacb) | `` chore(flake/git-hooks): 580633fa -> 3cfd774b ``                               |
| [`bd6364c9`](https://github.com/fredsystems/pre-commit-checks/commit/bd6364c9469a46d993e3877ee847f091cbe0916a) | `` chore(deps): update cachix/install-nix-action digest to 6165592 (#21) ``      |
| [`2d1712cb`](https://github.com/fredsystems/pre-commit-checks/commit/2d1712cbf87830342c8e25d4ab6cbb91b9484b5c) | `` chore(deps): update fredsystems/flake-update-action action to v3.0.4 (#22) `` |
| [`b2807cba`](https://github.com/fredsystems/pre-commit-checks/commit/b2807cba1c28c48bf51fd10f0920d5d089ca2900) | `` chore(flake/nixpkgs): 4c1018da -> 4bd9165a ``                                 |
| [`506e27f8`](https://github.com/fredsystems/pre-commit-checks/commit/506e27f8e88e3b5c02c52e82d8d86b30a7b821d8) | `` chore(flake/rust-overlay): 75356895 -> 62e3b8ae ``                            |
| [`d4877175`](https://github.com/fredsystems/pre-commit-checks/commit/d48771750f19b0b0b74d6d1029cacb073c84f3d9) | `` updates ``                                                                    |